### PR TITLE
fix endless loop when re-offsetting postponed updates

### DIFF
--- a/lib/src/diffutil_impl.dart
+++ b/lib/src/diffutil_impl.dart
@@ -554,6 +554,7 @@ class DiffResult<T> {
       if (update.posInOwnerList == posInList && update.removal == removal) {
         postponedUpdate = update;
         postponedUpdates.removeAt(i);
+        i++;
         break;
       }
       i++;
@@ -566,6 +567,7 @@ class DiffResult<T> {
       } else {
         update.currentPos++;
       }
+      i++;
     }
     return postponedUpdate;
   }


### PR DESCRIPTION
fixes #18 by aligning it with https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/recyclerview/recyclerview/src/main/java/androidx/recyclerview/widget/DiffUtil.java?source=post_page---------------------------%2F&autodive=0%2F#971